### PR TITLE
Allow optparse-applicative 0.15.1.0 and algebraic-graphs 0.5.

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -16,19 +16,19 @@ extra-doc-files:
 
 library
   build-depends:
-    algebraic-graphs     ^>= 0.4                    ,
-    base                 ^>= 4.13.0.0               ,
-    bytestring           ^>= 0.10.9.0               ,
-    containers           ^>= 0.6.2.1                ,
-    dhall                ^>= 1.30.0                 ,
-    directory            ^>= 1.3.3.2                ,
-    filepath             ^>= 1.4.2.1                ,
-    generic-lens         ^>= 1.1.0.0 || ^>= 2.0.0.0 ,
-    ghc                  ^>= 8.8.1                  ,
-    lens                 ^>= 4.18.1                 ,
-    mtl                  ^>= 2.2.2                  ,
-    optparse-applicative ^>= 0.14.3.0               ,
-    regex-tdfa           ^>= 1.3.1.0                ,
+    algebraic-graphs     ^>= 0.4 || ^>= 0.5           ,
+    base                 ^>= 4.13.0.0                 ,
+    bytestring           ^>= 0.10.9.0                 ,
+    containers           ^>= 0.6.2.1                  ,
+    dhall                ^>= 1.30.0                   ,
+    directory            ^>= 1.3.3.2                  ,
+    filepath             ^>= 1.4.2.1                  ,
+    generic-lens         ^>= 1.1.0.0 || ^>= 2.0.0.0   ,
+    ghc                  ^>= 8.8.1                    ,
+    lens                 ^>= 4.18.1                   ,
+    mtl                  ^>= 2.2.2                    ,
+    optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0 ,
+    regex-tdfa           ^>= 1.3.1.0                  ,
     transformers         ^>= 0.5.6.2
   hs-source-dirs: src
   exposed-modules:
@@ -40,14 +40,14 @@ library
 
 executable weeder
   build-depends:
-    base                 ^>= 4.13.0.0 ,
-    bytestring           ^>= 0.10.9.0 ,
-    containers           ^>= 0.6.2.1  ,
-    directory            ^>= 1.3.3.2  ,
-    filepath             ^>= 1.4.2.1  ,
-    ghc                  ^>= 8.8.1    ,
-    optparse-applicative ^>= 0.14.3.0 ,
-    transformers         ^>= 0.5.6.2  ,
+    base                 ^>= 4.13.0.0                 ,
+    bytestring           ^>= 0.10.9.0                 ,
+    containers           ^>= 0.6.2.1                  ,
+    directory            ^>= 1.3.3.2                  ,
+    filepath             ^>= 1.4.2.1                  ,
+    ghc                  ^>= 8.8.1                    ,
+    optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0 ,
+    transformers         ^>= 0.5.6.2                  ,
     weeder
   main-is: Main.hs
   hs-source-dirs: exe-weeder


### PR DESCRIPTION
This fixes GHC 8.8.3 build for me (via stackage lts-15.3 and
nightly-2020-03-14).