### PR TITLE
Make search directory configurable.

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -31,6 +31,7 @@ library
     mtl                  ^>= 2.2.2                                 ,
     optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0              ,
     regex-tdfa           ^>= 1.2.0.0 || ^>= 1.3.1.0                ,
+    text                 ^>= 1.2.3.0                               ,
     transformers         ^>= 0.5.6.2
   hs-source-dirs: src
   exposed-modules:


### PR DESCRIPTION
This is third in stack PR. This feels to be a missing configuration setting. (I feel I got confusing errors because of default `./.`).