### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.1
-    - uses: cachix/install-nix-action@v10
-    - uses: cachix/cachix-action@v6
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v8
       with:
         name: weeder
         signingKey: 7Pn6R7tF95HC2INHlVsphnqzZNT8Zmx3GBoqtwIvvH5F1SYlqVocPnR8aDds2qw4aYbNFGpMhpyY8G79e2OXcg==

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.1
     - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v8
       with:
         name: weeder

--- a/nix/haskell/cborg-json.nix
+++ b/nix/haskell/cborg-json.nix
@@ -6,6 +6,8 @@ mkDerivation {
   pname = "cborg-json";
   version = "0.2.2.0";
   sha256 = "ab68a2457cb71a76699d7a8df07a880ea70c51d2c1a891b12669ca9ccfa7517b";
+  revision = "2";
+  editedCabalFile = "1hbabjvmyqha75v2ivyvj6yzrnj9vs3h9988j4p68x9bcwmgyjyd";
   libraryHaskellDepends = [
     aeson aeson-pretty base cborg scientific text unordered-containers
     vector

--- a/nix/haskell/cborg.nix
+++ b/nix/haskell/cborg.nix
@@ -5,8 +5,8 @@
 }:
 mkDerivation {
   pname = "cborg";
-  version = "0.2.2.1";
-  sha256 = "ba920d368892fe14e048cd6ac4270ce4ea1aea0fb6a4998c5c97fe106e6c6183";
+  version = "0.2.4.0";
+  sha256 = "34ae38afffa078f8d394325937d0e15431069d4428a7449f6af9d2d16539367f";
   libraryHaskellDepends = [
     array base bytestring containers deepseq ghc-prim half integer-gmp
     primitive text

--- a/nix/haskell/dhall.nix
+++ b/nix/haskell/dhall.nix
@@ -2,36 +2,38 @@
 , base, bytestring, case-insensitive, cborg, cborg-json, containers
 , contravariant, cryptonite, data-fix, deepseq, Diff, directory
 , doctest, dotgen, either, exceptions, filepath, foldl, gauge
-, generic-random, hashable, haskeline, http-client, http-client-tls
-, http-types, lens-family-core, megaparsec, memory, mockery, mtl
-, network-uri, optparse-applicative, parser-combinators, parsers
-, pretty-simple, prettyprinter, prettyprinter-ansi-terminal
-, profunctors, QuickCheck, quickcheck-instances, repline
-, scientific, semigroups, serialise, special-values, spoon, stdenv
-, tasty, tasty-expected-failure, tasty-hunit, tasty-quickcheck
-, template-haskell, text, th-lift-instances, transformers
+, generic-random, half, hashable, haskeline, http-client
+, http-client-tls, http-types, lens-family-core, megaparsec, memory
+, mmorph, mockery, mtl, network-uri, optparse-applicative
+, parser-combinators, parsers, pretty-simple, prettyprinter
+, prettyprinter-ansi-terminal, profunctors, QuickCheck
+, quickcheck-instances, repline, scientific, semigroups, serialise
+, special-values, spoon, stdenv, tasty, tasty-expected-failure
+, tasty-hunit, tasty-quickcheck, template-haskell, text
+, text-manipulate, th-lift-instances, transformers
 , transformers-compat, turtle, unordered-containers, uri-encode
 , vector
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.30.0";
-  sha256 = "f2be9599ddd88602c1577b0ca57849c9827c9e700e105102cecc17c56b7c4a81";
-  revision = "1";
-  editedCabalFile = "1pazhb3h1rabb80wxh29k5yfp915zqp1gmhcv4mx7ibzv9zw7miq";
+  version = "1.34.0";
+  sha256 = "0dbc61611d465f744aec13fd3114a9d75bbaa434f1aaa3de7e49c385d9fe1b67";
+  revision = "2";
+  editedCabalFile = "1gvfcizp3blqas5ccgnqmahwq26xwd23kqh1vc9712agq7384z98";
   isLibrary = true;
   isExecutable = true;
+  enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson aeson-pretty ansi-terminal atomic-write base bytestring
     case-insensitive cborg cborg-json containers contravariant
     cryptonite data-fix deepseq Diff directory dotgen either exceptions
-    filepath hashable haskeline http-client http-client-tls http-types
-    lens-family-core megaparsec memory mtl network-uri
-    optparse-applicative parser-combinators parsers pretty-simple
-    prettyprinter prettyprinter-ansi-terminal profunctors repline
-    scientific serialise template-haskell text th-lift-instances
-    transformers transformers-compat unordered-containers uri-encode
-    vector
+    filepath half hashable haskeline http-client http-client-tls
+    http-types lens-family-core megaparsec memory mmorph mtl
+    network-uri optparse-applicative parser-combinators parsers
+    pretty-simple prettyprinter prettyprinter-ansi-terminal profunctors
+    repline scientific serialise template-haskell text text-manipulate
+    th-lift-instances transformers transformers-compat
+    unordered-containers uri-encode vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
@@ -39,8 +41,9 @@ mkDerivation {
     either filepath foldl generic-random lens-family-core megaparsec
     mockery prettyprinter QuickCheck quickcheck-instances scientific
     semigroups serialise special-values spoon tasty
-    tasty-expected-failure tasty-hunit tasty-quickcheck text
-    transformers turtle unordered-containers vector
+    tasty-expected-failure tasty-hunit tasty-quickcheck
+    template-haskell text transformers turtle unordered-containers
+    vector
   ];
   benchmarkHaskellDepends = [
     base bytestring containers directory gauge serialise text

--- a/nix/haskell/haskeline.nix
+++ b/nix/haskell/haskeline.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, bytestring, containers, directory, exceptions
+, filepath, HUnit, process, stdenv, stm, terminfo, text
+, transformers, unix
+}:
+mkDerivation {
+  pname = "haskeline";
+  version = "0.8.1.0";
+  sha256 = "bc9be8f7b5232e53f6f863828f1649a92a585ea1be254877c118cc42729fda64";
+  configureFlags = [ "-fterminfo" ];
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring containers directory exceptions filepath process
+    stm terminfo transformers unix
+  ];
+  executableHaskellDepends = [ base containers ];
+  testHaskellDepends = [
+    base bytestring containers HUnit process text unix
+  ];
+  doCheck = false;
+  homepage = "https://github.com/judah/haskeline";
+  description = "A command-line interface for user input, written in Haskell";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/haskell/lens.nix
+++ b/nix/haskell/lens.nix
@@ -1,36 +1,38 @@
-{ mkDerivation, array, base, base-orphans, bifunctors, bytestring
-, Cabal, cabal-doctest, call-stack, comonad, containers
+{ mkDerivation, array, base, base-compat, base-orphans, bifunctors
+, bytestring, Cabal, cabal-doctest, call-stack, comonad, containers
 , contravariant, criterion, deepseq, directory, distributive
 , doctest, exceptions, filepath, free, generic-deriving, ghc-prim
 , hashable, HUnit, kan-extensions, mtl, nats, parallel, profunctors
 , QuickCheck, reflection, semigroupoids, semigroups, simple-reflect
 , stdenv, tagged, template-haskell, test-framework
-, test-framework-hunit, test-framework-quickcheck2
-, test-framework-th, text, th-abstraction, transformers
-, transformers-compat, type-equality, unordered-containers, vector
+, test-framework-hunit, test-framework-quickcheck2, text
+, th-abstraction, transformers, transformers-compat
+, unordered-containers, vector
 }:
 mkDerivation {
   pname = "lens";
-  version = "4.18.1";
-  sha256 = "3107a3d5165a9762269d7c9e39205d2c4c2aaebc1900ff44a0066c31a492bdd2";
+  version = "4.19.2";
+  sha256 = "52f858ae3971a5104cdba5e81a27d154fda11fe65a54a4ac328c85904bdec23b";
+  revision = "2";
+  editedCabalFile = "1bp6s0ifwdmzv946krxgxqakw02iriqmzvvcypwrgcynrn9wkn9y";
   setupHaskellDepends = [ base Cabal cabal-doctest filepath ];
   libraryHaskellDepends = [
     array base base-orphans bifunctors bytestring call-stack comonad
     containers contravariant distributive exceptions filepath free
     ghc-prim hashable kan-extensions mtl parallel profunctors
     reflection semigroupoids tagged template-haskell text
-    th-abstraction transformers transformers-compat type-equality
+    th-abstraction transformers transformers-compat
     unordered-containers vector
   ];
   testHaskellDepends = [
     base bytestring containers deepseq directory doctest filepath
     generic-deriving HUnit mtl nats parallel QuickCheck semigroups
     simple-reflect test-framework test-framework-hunit
-    test-framework-quickcheck2 test-framework-th text transformers
-    unordered-containers vector
+    test-framework-quickcheck2 text transformers unordered-containers
+    vector
   ];
   benchmarkHaskellDepends = [
-    base bytestring comonad containers criterion deepseq
+    base base-compat bytestring comonad containers criterion deepseq
     generic-deriving transformers unordered-containers vector
   ];
   homepage = "http://github.com/ekmett/lens/";

--- a/nix/haskell/megaparsec.nix
+++ b/nix/haskell/megaparsec.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, criterion, deepseq, mtl, parser-combinators, scientific, stdenv
+, text, transformers, weigh
+}:
+mkDerivation {
+  pname = "megaparsec";
+  version = "8.0.0";
+  sha256 = "b5d7c64646016d12f540a6948396a86e0cd39865569d68fe2018fe9e3fce6318";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers deepseq mtl
+    parser-combinators scientific text transformers
+  ];
+  benchmarkHaskellDepends = [
+    base containers criterion deepseq text weigh
+  ];
+  homepage = "https://github.com/mrkkrp/megaparsec";
+  description = "Monadic parser combinators";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/haskell/repline.nix
+++ b/nix/haskell/repline.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, containers, exceptions, haskeline, mtl
+, process, stdenv
+}:
+mkDerivation {
+  pname = "repline";
+  version = "0.4.0.0";
+  sha256 = "43c28c49c8e16276d32d0889f37f750d7c7a8d2758f1d35a9f36e68944e457b7";
+  libraryHaskellDepends = [
+    base containers exceptions haskeline mtl process
+  ];
+  testHaskellDepends = [ base containers mtl process ];
+  homepage = "https://github.com/sdiehl/repline";
+  description = "Haskeline wrapper for GHCi-like REPL interfaces";
+  license = stdenv.lib.licenses.mit;
+}


### PR DESCRIPTION
This commit bumps the cachix-action and nix-install-action. We now have to specify a nixpkgs channel, and choosing 19.09 has needed a few other packages to be overriden.