### PR TITLE
Allow customization of HIE file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for Weeder
 
+### Unreleased
+
+- Allow configuration of the HIE file extension using the `--hie-extension` command-line flag
+
 ### [`2.1.3`][v2.1.3] - *2020-12-11*
 
 - Support `dhall-1.35`, `dhall-1.36` and `dhall-1.37`.

--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -64,19 +64,25 @@ import Paths_weeder (version)
 -- | Parse command line arguments and into a 'Config' and run 'mainWithConfig'.
 main :: IO ()
 main = do
-  (configExpr, hieDirectories) <-
+  (configExpr, hieExt, hieDirectories) <-
     execParser $
       info (optsP <**> helper <**> versionP) mempty
 
-  Dhall.input config configExpr >>= mainWithConfig hieDirectories
+  Dhall.input config configExpr >>= mainWithConfig hieExt hieDirectories
   where
-    optsP = (,)
+    optsP = (,,)
         <$> strOption
             ( long "config"
                 <> help "A Dhall expression for Weeder's configuration. Can either be a file path (a Dhall import) or a literal Dhall expression."
                 <> value "./weeder.dhall"
                 <> metavar "<weeder.dhall>"
                 <> showDefaultWith T.unpack
+            )
+        <*> strOption
+            ( long "hie-extension"
+                <> value ".hie"
+                <> help "Extension of HIE files"
+                <> showDefault
             )
         <*> many (
             strOption
@@ -94,13 +100,13 @@ main = do
 
 -- | Run Weeder in the current working directory with a given 'Config'.
 --
--- This will recursively find all @.hie@ files in the current directory, perform
+-- This will recursively find all files with the given extension in the given directories, perform
 -- analysis, and report all unused definitions according to the 'Config'.
-mainWithConfig :: [FilePath] -> Config -> IO ()
-mainWithConfig hieDirectories Config{ rootPatterns, typeClassRoots } = do
+mainWithConfig :: String -> [FilePath] -> Config -> IO ()
+mainWithConfig hieExt hieDirectories Config{ rootPatterns, typeClassRoots } = do
   hieFilePaths <-
     concat <$>
-      traverse getHieFilesIn
+      traverse ( getHieFilesIn hieExt )
         ( if null hieDirectories
           then ["./."]
           else hieDirectories
@@ -191,9 +197,14 @@ mainWithConfig hieDirectories Config{ rootPatterns, typeClassRoots } = do
   unless ( null warnings ) exitFailure
 
 
--- | Recursively search for .hie files in given directory
-getHieFilesIn :: FilePath -> IO [FilePath]
-getHieFilesIn path = do
+-- | Recursively search for files with the given extension in given directory
+getHieFilesIn
+  :: String
+  -- ^ Only files with this extension are considered
+  -> FilePath
+  -- ^ Directory to look in
+  -> IO [FilePath]
+getHieFilesIn ext path = do
   exists <-
     doesPathExist path
 
@@ -202,7 +213,7 @@ getHieFilesIn path = do
       isFile <-
         doesFileExist path
 
-      if isFile && "hie" `isExtensionOf` path
+      if isFile && ext `isExtensionOf` path
         then do
           path' <-
             canonicalizePath path
@@ -218,7 +229,7 @@ getHieFilesIn path = do
               cnts <-
                 listDirectory path
 
-              withCurrentDirectory path ( foldMap getHieFilesIn cnts )
+              withCurrentDirectory path ( foldMap ( getHieFilesIn ext ) cnts )
 
             else
               return []


### PR DESCRIPTION
Given the `--hie-extension=.custom_hie` flag, weeder will only consider files with the `.custom_hie` extension within the given HIE directories.