### PR TITLE
Fix nix-shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-eval "$(lorri direnv)"
+use nix

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 let
-  hsPkgs = import ./default.nix {};
+  hsPkgs = import ./default.nix;
 in
 hsPkgs.shellFor {
   withHoogle = true;


### PR DESCRIPTION
Corrects nix-shell itself, and changes the .envrc file to just call `use nix`.