### PR TITLE
Analyse top-level pattern bindings

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v8
+    - uses: cachix/cachix-action@v10
       with:
         name: weeder
         signingKey: 7Pn6R7tF95HC2INHlVsphnqzZNT8Zmx3GBoqtwIvvH5F1SYlqVocPnR8aDds2qw4aYbNFGpMhpyY8G79e2OXcg==

--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -264,7 +264,8 @@ topLevelAnalysis n@Node{ nodeChildren } = do
 
 analyseBinding :: ( Alternative m, MonadState Analysis m ) => HieAST a -> m ()
 analyseBinding n@Node{ nodeSpan, sourcedNodeInfo } = do
-  guard $ any (Set.member ("FunBind", "HsBindLR") . nodeAnnotations) $ getSourcedNodeInfo sourcedNodeInfo
+  let bindAnns = Set.fromList [("FunBind", "HsBindLR"), ("PatBind", "HsBindLR")]
+  guard $ any (not . Set.disjoint bindAnns . nodeAnnotations) $ getSourcedNodeInfo sourcedNodeInfo
 
   for_ ( findDeclarations n ) \d -> do
     define d nodeSpan


### PR DESCRIPTION
Closes #92 

With this patch, weeder correctly outputs  
```
app/Dep.hs:7: b
```
for the example in #92, so both the false negative and false positive are fixed by this.

---

The binding 
```haskell
(a, b) = (xxx, 1)
```
has HIE AST
```haskell
Node app/Dep.hs:7:1-17 [(AbsBinds, HsBindLR),
                        (PatBind, HsBindLR)] [] []
  Node app/Dep.hs:7:1-6 [(TuplePat, Pat)] [1] []
      Node app/Dep.hs:7:2 [(VarPat, Pat)] [0] [(Right a,
                                                IdentifierDetails Just 0 {PatternBind ModuleScope (LocalScope SrcSpanOneLine "app/Dep.hs" 7 5 6) (Just SrcSpanOneLine "app/Dep.hs" 7 1 18)})]
      Node app/Dep.hs:7:5 [(VarPat, Pat)] [0] [(Right b,
                                                IdentifierDetails Just 0 {PatternBind ModuleScope NoScope (Just SrcSpanOneLine "app/Dep.hs" 7 1 18)})]
  Node app/Dep.hs:7:8-17 [(GRHS, GRHS)] [] []
      Node app/Dep.hs:7:10-17 [(ExplicitTuple, HsExpr)] [] []
            Node app/Dep.hs:7:11-13 [(HsVar, HsExpr),
                                     (Present, HsTupArg)] [0] [(Right xxx,
                                                                IdentifierDetails Just 0 {Use})]
            Node app/Dep.hs:7:16 [(HsOverLit, HsExpr),
                                  (Present, HsTupArg)] [0] []
```
so I hope that `PatBind` is the correct thing to look out for in additon to `FunBind`.