### PR TITLE
Allow algebraic-graphs 0.6 series

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -18,7 +18,7 @@ extra-doc-files:
 
 library
   build-depends:
-    , algebraic-graphs     ^>= 0.4 || ^>= 0.5
+    , algebraic-graphs     ^>= 0.4 || ^>= 0.5 || ^>= 0.6
     , base                 ^>= 4.15.0.0
     , bytestring           ^>= 0.10.9.0 || ^>= 0.11.0.0
     , containers           ^>= 0.6.2.1


### PR DESCRIPTION
This was tested with stackage lts-19.2. Without this change, the weeder doesn't run on this lts.
