### PR TITLE
Shorter help for require-hs-files.

### DIFF
--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -90,7 +90,7 @@ main = do
             )
         <*> switch
               ( long "require-hs-files"
-                  <> help "Requires that all .hie files have matching .hs files. This can help deal with skipping .hie files for Haskell modules that have since been removed"
+                  <> help "Skip stale .hie files with no matching .hs modules"
               )
 
     versionP = infoOption ( "weeder version "


### PR DESCRIPTION
A shorter help description for `require-hs-files` that doesn't give up any of the intent of the original.

Rendered:

```
ghci> :main --help
Usage: <interactive> [--config <weeder.dhall>] [--hie-extension ARG]
                     [--hie-directory ARG] [--require-hs-files] [--version]

Available options:
  --config <weeder.dhall>  A Dhall expression for Weeder's configuration. Can
                           either be a file path (a Dhall import) or a literal
                           Dhall expression. (default: ./weeder.dhall)
  --hie-extension ARG      Extension of HIE files (default: ".hie")
  --hie-directory ARG      A directory to look for .hie files in. Maybe
                           specified multiple times. Default ./.
  --require-hs-files       Skip stale .hie files with no matching .hs modules
  -h,--help                Show this help text
  --version                Show version
```