### PR TITLE
Support GHC 9.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,4 @@ source-repository-package
   location: https://github.com/scarf-sh/cborg
   tag: 8dae0d21e6f17e30785f35bb3ef5eb611863a904
   subdir: cborg
+  --sha256: sha256-SAHFIlN5QKQKJFhHliXvXOQhrqvsE/TLvY2rkftXkHM=

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,9 @@
 packages:
   weeder.cabal
+
+-- https://github.com/well-typed/cborg/pull/304
+source-repository-package
+  type: git
+  location: https://github.com/scarf-sh/cborg
+  tag: 8dae0d21e6f17e30785f35bb3ef5eb611863a904
+  subdir: cborg

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler-nix-name ? "ghc925" }:
+{ compiler-nix-name ? "ghc943" }:
 let
   haskellNix = import (import ./nix/sources.nix)."haskell.nix" {};
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e339ff5b2862443f19971c524a09169c10706aaa",
-        "sha256": "0r6sjxl89i297ibvqx4zs5dvkjd9hhp4zyspalva94mbzaxl8404",
+        "rev": "9cd5fc04b9577d951eca4718b4066f4259bcba5e",
+        "sha256": "0rydx3z29g80kp51s4wlkh3r8zfnjdnmbbgikhsbalplpnqm8kmz",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/e339ff5b2862443f19971c524a09169c10706aaa.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/9cd5fc04b9577d951eca4718b4066f4259bcba5e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -19,19 +19,19 @@ extra-doc-files:
 library
   build-depends:
     , algebraic-graphs     ^>= 0.4 || ^>= 0.5  || ^>= 0.6
-    , base                 ^>= 4.16.0.0
+    , base                 ^>= 4.17.0.0
     , bytestring           ^>= 0.10.9.0 || ^>= 0.11.0.0
     , containers           ^>= 0.6.2.1
     , dhall                ^>= 1.30.0 || ^>= 1.31.0 || ^>= 1.32.0 || ^>= 1.33.0 || ^>= 1.34.0 || ^>= 1.35.0 || ^>= 1.36.0 || ^>= 1.37.0 || ^>= 1.40.0 || ^>= 1.41
     , directory            ^>= 1.3.3.2
     , filepath             ^>= 1.4.2.1
     , generic-lens         ^>= 2.2.0.0
-    , ghc                  ^>= 9.2
+    , ghc                  ^>= 9.4
     , lens                 ^>= 5.1 || ^>= 5.2
     , mtl                  ^>= 2.2.2
     , optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0 || ^>= 0.16.0.0 || ^>=  0.17
     , regex-tdfa           ^>= 1.2.0.0 || ^>= 1.3.1.0
-    , text                 ^>= 1.2.3.0
+    , text                 ^>= 2.0.1
     , transformers         ^>= 0.5.6.2 || ^>= 0.6
   hs-source-dirs: src
   exposed-modules:


### PR DESCRIPTION
Fixes #109.

This also drops support for GHC 9.2. It doesn't look terribly hard to support both with CPP. But based on previous PRs (#94, #68) it seemed like this approach was preferred. 

I didn't touch any of the Nix stuff. I don't use Nix myself, so I wouldn't know how to verify that my changes worked. 