### PR TITLE
Sort weeds by line number

### DIFF
--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -14,7 +14,7 @@ import Control.Monad ( guard, unless, when )
 import Control.Monad.IO.Class ( liftIO )
 import Data.Bool
 import Data.Foldable
-import Data.List ( isSuffixOf )
+import Data.List ( isSuffixOf, sortOn )
 import Data.Version ( showVersion )
 import System.Exit ( exitFailure )
 
@@ -162,7 +162,7 @@ mainWithConfig hieExt hieDirectories requireHsFiles Config{ rootPatterns, typeCl
         dead
 
   for_ ( Map.toList warnings ) \( path, declarations ) ->
-    for_ declarations \( start, d ) ->
+    for_ (sortOn (srcLocLine . fst) declarations) \( start, d ) ->
       putStrLn $ showWeed path start d
 
   unless ( null warnings ) exitFailure


### PR DESCRIPTION
Weeds within the same module are now sorted by their line number, instead of being sorted alphabetically.

Before:
```
test/functional/Symbol.hs:145: aR
test/functional/Symbol.hs:143: aSR
test/functional/Symbol.hs:149: bR
test/functional/Symbol.hs:147: bSR
test/functional/Symbol.hs:129: barR
test/functional/Symbol.hs:127: barSR
test/functional/Symbol.hs:137: catR
test/functional/Symbol.hs:135: catSR
test/functional/Symbol.hs:133: dogR
test/functional/Symbol.hs:131: dogSR
test/functional/Symbol.hs:125: fooR
test/functional/Symbol.hs:123: fooSR
test/functional/Symbol.hs:111: fromList
test/functional/Symbol.hs:119: importDataMaybeR
test/functional/Symbol.hs:121: importDataMaybeSR
test/functional/Symbol.hs:115: importsR
test/functional/Symbol.hs:117: importsSR
test/functional/Symbol.hs:141: myDataR
test/functional/Symbol.hs:139: myDataSR
test/functional/Symbol.hs:108: oldCaps
test/functional/Symbol.hs:65: pre310Tests
test/functional/Symbol.hs:153: testPatternR
test/functional/Symbol.hs:151: testPatternSR
test/functional/Symbol.hs:13: tests
test/functional/Symbol.hs:19: v310Tests
```
After:
```
test/functional/Symbol.hs:19: v310Tests
test/functional/Symbol.hs:65: pre310Tests
test/functional/Symbol.hs:108: oldCaps
test/functional/Symbol.hs:111: fromList
test/functional/Symbol.hs:115: importsR
test/functional/Symbol.hs:117: importsSR
test/functional/Symbol.hs:119: importDataMaybeR
test/functional/Symbol.hs:121: importDataMaybeSR
test/functional/Symbol.hs:123: fooSR
test/functional/Symbol.hs:125: fooR
test/functional/Symbol.hs:127: barSR
test/functional/Symbol.hs:129: barR
test/functional/Symbol.hs:131: dogSR
test/functional/Symbol.hs:133: dogR
test/functional/Symbol.hs:135: catSR
test/functional/Symbol.hs:137: catR
test/functional/Symbol.hs:139: myDataSR
test/functional/Symbol.hs:141: myDataR
test/functional/Symbol.hs:143: aSR
test/functional/Symbol.hs:145: aR
test/functional/Symbol.hs:147: bSR
test/functional/Symbol.hs:149: bR
test/functional/Symbol.hs:151: testPatternSR
test/functional/Symbol.hs:153: testPatternR
```