### PR TITLE
Add --no-exit-code option

### DIFF
--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -16,7 +16,7 @@ import Data.Bool
 import Data.Foldable
 import Data.List ( isSuffixOf, sortOn )
 import Data.Version ( showVersion )
-import System.Exit ( exitFailure, ExitCode(..), exitWith )
+import System.Exit ( exitFailure, ExitCode(..), exitSuccess, exitWith )
 
 -- containers
 import qualified Data.Map.Strict as Map
@@ -60,7 +60,7 @@ import Paths_weeder (version)
 -- | Parse command line arguments and into a 'Config' and run 'mainWithConfig'.
 main :: IO ()
 main = do
-  (configExpr, hieExt, hieDirectories, requireHsFiles) <-
+  (configExpr, hieExt, hieDirectories, requireHsFiles, noExit) <-
     execParser $
       info (optsP <**> helper <**> versionP) mempty
 
@@ -69,9 +69,11 @@ main = do
       >>= either throwIO pure
       >>= mainWithConfig hieExt hieDirectories requireHsFiles
   
-  exitWith exitCode
+  if noExit
+    then exitSuccess
+    else exitWith exitCode
   where
-    optsP = (,,,)
+    optsP = (,,,,)
         <$> strOption
             ( long "config"
                 <> help "A file path for Weeder's configuration."
@@ -94,6 +96,10 @@ main = do
         <*> switch
               ( long "require-hs-files"
                   <> help "Skip stale .hie files with no matching .hs modules"
+              )
+        <*> switch
+              ( long "no-exit-code"
+                  <> help "Do not give a negative exit if weeds"
               )
 
     versionP = infoOption ( "weeder version "


### PR DESCRIPTION
In freckle/weeder-action, we don't want weeder to exit non-zero when
weeds are found because that would fail the Job. We want to capture and
process things ourselves.

Without this option, we had to resort to `|| true`, which means we don't
behave correctly when there are non-weed problems (failure to read
config, for example). These cases just appear successful. This is
particularly bad for new projects which don't have a `weeder.dhall` yet.
The team is never alerted to add it because the weeder-action just
succeeds, even though that should be a fatal error.

In adding the option, I copied HLint exactly in the name of the flag and
the help message. I find the language a little stilted, to be honest, so
I'm totally open to making it whatever you like; I just through being
consistent with an existing tool could be valuable.
