### PR TITLE
Combine root-instances and root-classes

### DIFF
--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -201,8 +201,9 @@ data Root
     DeclarationRoot Declaration
   | -- | We store extra information for instances in order to be able
     -- to specify e.g. all instances of a class as roots.
-    InstanceRoot Declaration
-      OccName -- ^ Name of the parent class
+    InstanceRoot 
+      Declaration -- ^ Declaration of the instance
+      Declaration -- ^ Declaration of the parent class
   | -- | All exported declarations in a module are roots.
     ModuleRoot Module
   deriving
@@ -335,7 +336,8 @@ addImplicitRoot x =
 
 addInstanceRoot :: ( MonadState Analysis m, MonadReader AnalysisInfo m ) => Declaration -> TypeIndex -> Name -> m ()
 addInstanceRoot x t cls = do
-  #implicitRoots %= Set.insert (InstanceRoot x (nameOccName cls))
+  for_ (nameToDeclaration cls) \cls' ->
+    #implicitRoots %= Set.insert (InstanceRoot x cls')
 
   -- since instances will not appear in the output if typeClassRoots is True
   Config{ typeClassRoots } <- asks weederConfig

--- a/src/Weeder/Config.hs
+++ b/src/Weeder/Config.hs
@@ -76,7 +76,7 @@ defaultConfig :: Config
 defaultConfig = Config
   { rootPatterns = Set.fromList [ "Main.main", "^Paths_.*"]
   , typeClassRoots = False
-  , rootInstances = Set.fromList [ ClassOnly "IsString", ClassOnly "IsList" ]
+  , rootInstances = Set.fromList [ ClassOnly "\\.IsString$", ClassOnly "\\.IsList$" ]
   , unusedTypes = False
   }
 

--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -174,7 +174,7 @@ mainWithConfig hieExt hieDirectories requireHsFiles weederConfig@Config{ rootPat
       Set.filter
         ( \d ->
             any
-              ( ( moduleNameString ( moduleName ( declModule d ) ) <> "." <> occNameString ( declOccName d ) ) =~ )
+              ( displayDeclaration d =~ )
               rootPatterns
         )
         ( allDeclarations analysis )
@@ -228,12 +228,17 @@ mainWithConfig hieExt hieDirectories requireHsFiles weederConfig@Config{ rootPat
           filteredInstances :: Set (Maybe String)
           filteredInstances = 
             Set.map instancePattern 
-            . Set.filter (maybe True (occNameString c =~) . classPattern) 
+            . Set.filter (maybe True (displayDeclaration c =~) . classPattern) 
             . Set.filter (maybe True modulePathMatches . modulePattern) 
             $ rootInstances
 
           modulePathMatches :: String -> Bool
           modulePathMatches p = maybe False (=~ p) (Map.lookup ( declModule d ) modulePaths)
+
+
+displayDeclaration :: Declaration -> String
+displayDeclaration d = 
+  moduleNameString ( moduleName ( declModule d ) ) <> "." <> occNameString ( declOccName d )
 
 
 showWeed :: FilePath -> RealSrcLoc -> Declaration -> String

--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -141,7 +141,7 @@ main = do
 -- This will recursively find all files with the given extension in the given directories, perform
 -- analysis, and report all unused definitions according to the 'Config'.
 mainWithConfig :: String -> [FilePath] -> Bool -> Config -> IO (ExitCode, Analysis)
-mainWithConfig hieExt hieDirectories requireHsFiles weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, rootClasses } = do
+mainWithConfig hieExt hieDirectories requireHsFiles weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances } = do
   hieFilePaths <-
     concat <$>
       traverse ( getFilesIn hieExt )
@@ -218,16 +218,19 @@ mainWithConfig hieExt hieDirectories requireHsFiles weederConfig@Config{ rootPat
 
       ModuleRoot _ -> True
 
-      InstanceRoot d c -> typeClassRoots || matchingClass || matchingType
+      InstanceRoot d c -> typeClassRoots || matchingType
         where
-          matchingClass = any (maybe True (occNameString c =~)) (filterOnModule rootClasses)
+          matchingType = 
+            let mt = Map.lookup d prettyPrintedType
+                matches = maybe (const False) (=~) mt
+            in any (maybe True matches) filteredInstances
 
-          matchingType = case Map.lookup d prettyPrintedType of
-            Just t -> any (maybe True (t =~)) (filterOnModule rootInstances)
-            Nothing -> False
-
-          filterOnModule :: Set PatternWithModule -> Set (Maybe String)
-          filterOnModule = Set.map mainPattern . Set.filter (maybe True modulePathMatches . modulePattern)
+          filteredInstances :: Set (Maybe String)
+          filteredInstances = 
+            Set.map instancePattern 
+            . Set.filter (maybe True (occNameString c =~) . classPattern) 
+            . Set.filter (maybe True modulePathMatches . modulePattern) 
+            $ rootInstances
 
           modulePathMatches :: String -> Bool
           modulePathMatches p = maybe False (=~ p) (Map.lookup ( declModule d ) modulePaths)

--- a/test/Spec/ConfigInstanceModules.toml
+++ b/test/Spec/ConfigInstanceModules.toml
@@ -1,6 +1,6 @@
 root-instances = [ { module = "Spec.ConfigInstanceModules.Module1", instance = "Bounded T" }
                  , "Read T" 
                  , { module = "Spec.ConfigInstanceModules.Module3" }
-                 , { class = "Enum" }
-                 , { module = "Spec.ConfigInstanceModules.Module2", class = "Show" } 
+                 , { class = '\.Enum$' }
+                 , { module = "Spec.ConfigInstanceModules.Module2", class = '\.Show$' } 
                  ]

--- a/test/Spec/ConfigInstanceModules.toml
+++ b/test/Spec/ConfigInstanceModules.toml
@@ -1,8 +1,6 @@
 root-instances = [ { module = "Spec.ConfigInstanceModules.Module1", instance = "Bounded T" }
                  , "Read T" 
                  , { module = "Spec.ConfigInstanceModules.Module3" }
+                 , { class = "Enum" }
+                 , { module = "Spec.ConfigInstanceModules.Module2", class = "Show" } 
                  ]
-
-root-classes = [ { class = "Enum" }
-               , { module = "Spec.ConfigInstanceModules.Module2", class = "Show" } 
-               ]

--- a/test/Spec/InstanceRootConstraint.toml
+++ b/test/Spec/InstanceRootConstraint.toml
@@ -2,6 +2,4 @@ roots = []
 
 type-class-roots = false
 
-root-classes = []
-
 root-instances = [ 'Foo a => Foo \[a\]' ]

--- a/test/Spec/OverloadedLists.toml
+++ b/test/Spec/OverloadedLists.toml
@@ -1,6 +1,6 @@
 roots = [ "Spec.OverloadedLists.OverloadedLists.root"
         , "Spec.OverloadedLists.OverloadedLists.BetterList" ]
 
-root-classes = []
+root-instances = []
 
 type-class-roots = false

--- a/test/Spec/OverloadedStrings.toml
+++ b/test/Spec/OverloadedStrings.toml
@@ -3,6 +3,6 @@ roots = [ "Spec.OverloadedStrings.OverloadedStrings.root"
         , "Spec.OverloadedStrings.OverloadedStrings.BetterString"
         ]
 
-root-classes = []
+root-instances = []
 
 type-class-roots = false

--- a/test/Spec/RootClasses.toml
+++ b/test/Spec/RootClasses.toml
@@ -2,4 +2,4 @@ roots = []
 
 type-class-roots = false
 
-root-classes = [ "Show", "Ord", "Bar" ]
+root-instances = [ {class = "Show"}, {class = "Ord"}, {class = "Bar"} ]

--- a/test/Spec/RootClasses.toml
+++ b/test/Spec/RootClasses.toml
@@ -2,4 +2,4 @@ roots = []
 
 type-class-roots = false
 
-root-instances = [ {class = "Show"}, {class = "Ord"}, {class = "Bar"} ]
+root-instances = [ {class = '\.Show$'}, {class = '\.Ord$'}, {class = '\.Bar$'} ]

--- a/test/Spec/TypeAliasGADT.toml
+++ b/test/Spec/TypeAliasGADT.toml
@@ -4,6 +4,4 @@ type-class-roots = false
 
 unused-types = true
 
-root-classes = []
-
 root-instances = []

--- a/test/Spec/TypeDataDecl.toml
+++ b/test/Spec/TypeDataDecl.toml
@@ -5,5 +5,3 @@ type-class-roots = false
 unused-types = true
 
 root-instances = []
-
-root-classes = []

--- a/test/UnitTests/Weeder/ConfigSpec.hs
+++ b/test/UnitTests/Weeder/ConfigSpec.hs
@@ -19,8 +19,7 @@ prop_configToToml =
   let cf = Config
         { rootPatterns = mempty
         , typeClassRoots = True
-        , rootClasses = Set.fromList [ModuleOnly "Baz", PatternAndModule "foo\\\\[bar]" "Bar\\\\.foo", PatternOnly "b\\"]
-        , rootInstances = Set.fromList [ModuleOnly "Quux\\\\[\\]", PatternAndModule "[\\[\\\\[baz" "[Quuux]", PatternOnly "a"]
+        , rootInstances = Set.fromList [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"]
         , unusedTypes = True
         }
       cf' = T.pack $ configToToml cf

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -35,7 +35,6 @@ library
     , optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0 || ^>= 0.16.0.0 || ^>=  0.17
     , regex-tdfa           ^>= 1.2.0.0 || ^>= 1.3.1.0
     , text                 ^>= 2.0.1
-    , these
     , toml-reader          ^>= 0.2.0.0
     , transformers         ^>= 0.5.6.2 || ^>= 0.6
   hs-source-dirs: src

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -35,6 +35,7 @@ library
     , optparse-applicative ^>= 0.14.3.0 || ^>= 0.15.1.0 || ^>= 0.16.0.0 || ^>=  0.17
     , regex-tdfa           ^>= 1.2.0.0 || ^>= 1.3.1.0
     , text                 ^>= 2.0.1
+    , these
     , toml-reader          ^>= 0.2.0.0
     , transformers         ^>= 0.5.6.2 || ^>= 0.6
   hs-source-dirs: src


### PR DESCRIPTION
`root-instances` and `root-classes` both fulfil the same purpose of marking instances as roots, differing only in `root-classes` having a `class` field that matches on the parent class of the instance, and `root-instances` having an `instance` field that matches on the pretty-printed type of the instance. Since we use TOML tables as of #133, we can make elements of `root-instances` have both `class` and `instance` fields.

Additionally, `class` now matches on the full class declaration like `roots`, instead of just the `OccName`.