### PR TITLE
Prune unused build-depends from executable

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -52,17 +52,9 @@ library
   ghc-options: -Wall -fwarn-incomplete-uni-patterns -threaded
   default-language: Haskell2010
 
-
 executable weeder
   build-depends:
     , base
-    , bytestring
-    , containers
-    , directory
-    , filepath
-    , ghc
-    , optparse-applicative
-    , transformers
     , weeder
   main-is: Main.hs
   hs-source-dirs: exe-weeder


### PR DESCRIPTION
The executable just calls a main function from the library, so it only
depends on the library and `base`.