### PR TITLE
Add root-modules field

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ in the Dhall project).
 | ---------------- | ------------------------------------ | --- |
 | roots            | `[ "Main.main", "^Paths_weeder.*" ]` | Any declarations matching these regular expressions will be considered as alive. |
 | type-class-roots | `false`                              | Consider all instances of type classes as roots. Overrides `root-instances`. |
-| root-instances   | `[ {class = '\.IsString$'}, {class = '\.IsList$'} ]` | Type class instances that match on all specified fields will be considered as roots. Accepts the fields `instance` matching on the pretty-printed type of the instance (visible in the output), `class` matching on its parent class declaration, and `module` matching on the module the instance is in. |
+| root-instances   | `[ {class = '\.IsString$'}, {class = '\.IsList$'} ]` | Type class instances that match on all specified fields will be considered as roots. Accepts the fields `instance` matching on the pretty-printed type of the instance (visible in the output), `class` matching on its parent class declaration, and `module` matching on the module the instance is defined in. |
+| root-modules     | `[]`                                 | The exports of all matching modules will be considered as alive. This does not include type class instances implicitly exported by the module.
 | unused-types     | `false`                              | Enable analysis of unused types. |
 
 `root-instances` can also accept string literals as a shorthand for writing a table

--- a/test/Spec/ModuleRoot.stdout
+++ b/test/Spec/ModuleRoot.stdout
@@ -1,0 +1,2 @@
+test/Spec/ModuleRoot/InstanceNotRoot.hs:9: (Instance) :: C T
+test/Spec/ModuleRoot/M.hs:11: weed

--- a/test/Spec/ModuleRoot.toml
+++ b/test/Spec/ModuleRoot.toml
@@ -1,0 +1,5 @@
+roots = []
+
+root-modules = [ '^Spec\.ModuleRoot\.M$', '^Spec\.ModuleRoot\.InstanceNotRoot$' ]
+
+type-class-roots = false

--- a/test/Spec/ModuleRoot/InstanceNotRoot.hs
+++ b/test/Spec/ModuleRoot/InstanceNotRoot.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+module Spec.ModuleRoot.InstanceNotRoot (C(..), T(..)) where
+
+class C a where
+  method :: a -> a
+
+data T = T
+
+instance C T where
+  method = id

--- a/test/Spec/ModuleRoot/M.hs
+++ b/test/Spec/ModuleRoot/M.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+module Spec.ModuleRoot.M (root) where
+
+root :: ()
+root = dependency
+
+dependency :: ()
+dependency = ()
+
+weed :: ()
+weed = ()

--- a/test/UnitTests/Weeder/ConfigSpec.hs
+++ b/test/UnitTests/Weeder/ConfigSpec.hs
@@ -20,6 +20,7 @@ prop_configToToml =
         , typeClassRoots = True
         , rootInstances = [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"]
         , unusedTypes = True
+        , rootModules = ["Foo\\.Bar", "Baz"]
         }
       cf' = T.pack $ configToToml cf
    in TOML.decode cf' == Right cf

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -92,6 +92,8 @@ test-suite weeder-test
     Spec.DeriveGeneric.DeriveGeneric
     Spec.InstanceRootConstraint.InstanceRootConstraint
     Spec.InstanceTypeclass.InstanceTypeclass
+    Spec.ModuleRoot.InstanceNotRoot
+    Spec.ModuleRoot.M
     Spec.Monads.Monads
     Spec.NumInstance.NumInstance
     Spec.NumInstanceLiteral.NumInstanceLiteral


### PR DESCRIPTION
Fixes #40

This adds a `root-modules` field, which marks all exports of a module as roots.

Currently the exports marked as roots do not include any exported instances, as that is the simplest option. A possible alternative is to consider which instances would be accessible by someone importing the root module (e.g. if both the class and the datatype are exported).

The implementation re-adds `analyseExport` to `Weeder.hs`, but rewritten to be compatible with GHC 9.8.