### PR TITLE
Display toml parse errors correctly

### DIFF
--- a/src/Weeder/Main.hs
+++ b/src/Weeder/Main.hs
@@ -191,7 +191,7 @@ main = handleWeederException do
     >>= mainWithConfig hieExt hieDirectories requireHsFiles
   where
     throwConfigError e =
-      throwIO $ ExitConfigFailure (show e)
+      throwIO $ ExitConfigFailure (displayException e)
 
     decodeConfig noDefaultFields =
       if noDefaultFields


### PR DESCRIPTION
Given the following invalid TOML:
```toml
roots = [ "Main.main", "^
```

Before:
```
ParseError "./weeder.toml:1:24:\n  |\n1 | roots = [ \"Main.main\", \"^\n  |                        ^\nunexpected '\"'\nexpecting ']' or white space\n"
```

After:
```
./weeder.toml:1:24:
  |
1 | roots = [ "Main.main", "^
  |                        ^
unexpected '"'
expecting ']' or white space
```