### PR TITLE
Add terminfo dep (for older ghc versions)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
               reinstallableLibGhc = false;
               enableLibraryProfiling = true;
               nonReinstallablePkgs = [
-                "rts" "ghc-prim" "integer-gmp" "integer-simple" "base"
+                "rts" "ghc-prim" "integer-gmp" "integer-simple" "base" "terminfo"
                 "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
                 "ghc-bignum" "system-cxx-std-lib" "ghc" "binary" "bytestring" "containers" 
                 "directory" "exceptions" "filepath" "hpc" "process" "semaphore-compat" "stm" 


### PR DESCRIPTION
@ocharles your suggestion worked, here's the PR. if you want to compile weeder for running against code compiled by ghc-9.4.8, this change seems to help.