### PR TITLE
Use `program-options` instead of `package *` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you use Cabal, this is easily done by adding one line to your
 `cabal.project.local` file:
 
 ``` cabal
-package *
+program-options
   ghc-options: -fwrite-ide-info
 ```
 


### PR DESCRIPTION
Closes https://github.com/ocharles/weeder/issues/91. I forget the exact syntax every few months, and end up searching for that PR...

I'm not certain, but I don't know of any downsides to suggesting always using this approach, rather than continuing to recommend the old way as an option.