### PR TITLE
Don't use `requireHsFiles` when running tests

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -75,7 +75,7 @@ discoverIntegrationTests = do
 -- Also creates a dotfile containing the dependency graph as seen by Weeder
 integrationTestOutput :: FilePath -> IO LBS.ByteString
 integrationTestOutput hieDirectory = do
-  hieFiles <- Weeder.Main.getHieFiles ".hie" [hieDirectory] True
+  hieFiles <- Weeder.Main.getHieFiles ".hie" [hieDirectory] False
   weederConfig <- TOML.decodeFile configExpr >>= either throwIO pure
   let (weeds, analysis) = Weeder.Run.runWeeder weederConfig hieFiles
       graph = Weeder.dependencyGraph analysis


### PR DESCRIPTION
This causes a directory listing of `./.` to be forced (to find all `.hs` files), which for my checkout is a huge search. We don't really need this check though, so for tests it can be turned off. For me, this brings test execution time all the way down to <0.1s