### PR TITLE
Add failing TemplateHaskell test

### DIFF
--- a/test/Spec/TemplateHaskell.failing
+++ b/test/Spec/TemplateHaskell.failing
@@ -1,0 +1,7 @@
+test/Spec/TemplateHaskell/TH.hs:7: oneQ
+test/Spec/TemplateHaskell/TH.hs:10: one
+test/Spec/TemplateHaskell/TH.hs:13: intQQ
+test/Spec/TemplateHaskell/TH.hs:21: zero1
+test/Spec/TemplateHaskell/TH.hs:24: zero2
+test/Spec/TemplateHaskell/TH.hs:27: zero3
+test/Spec/TemplateHaskell/TH.hs:30: zero4

--- a/test/Spec/TemplateHaskell.failing
+++ b/test/Spec/TemplateHaskell.failing
@@ -1,5 +1,6 @@
-main: test/Spec/TemplateHaskell/TH.hs:13:1: intQQ
-main: test/Spec/TemplateHaskell/TH.hs:21:1: zero1
-main: test/Spec/TemplateHaskell/TH.hs:24:1: zero2
-main: test/Spec/TemplateHaskell/TH.hs:27:1: zero3
-main: test/Spec/TemplateHaskell/TH.hs:30:1: zero4
+main: test/Spec/TemplateHaskell/TH.hs:22:1: threeQ
+main: test/Spec/TemplateHaskell/TH.hs:25:1: intQQ
+main: test/Spec/TemplateHaskell/TH.hs:33:1: zero1
+main: test/Spec/TemplateHaskell/TH.hs:36:1: zero2
+main: test/Spec/TemplateHaskell/TH.hs:39:1: zero3
+main: test/Spec/TemplateHaskell/TH.hs:42:1: zero4

--- a/test/Spec/TemplateHaskell.failing
+++ b/test/Spec/TemplateHaskell.failing
@@ -1,7 +1,7 @@
-test/Spec/TemplateHaskell/TH.hs:7: oneQ
-test/Spec/TemplateHaskell/TH.hs:10: one
-test/Spec/TemplateHaskell/TH.hs:13: intQQ
-test/Spec/TemplateHaskell/TH.hs:21: zero1
-test/Spec/TemplateHaskell/TH.hs:24: zero2
-test/Spec/TemplateHaskell/TH.hs:27: zero3
-test/Spec/TemplateHaskell/TH.hs:30: zero4
+main: test/Spec/TemplateHaskell/TH.hs:7:1: oneQ
+main: test/Spec/TemplateHaskell/TH.hs:10:1: one
+main: test/Spec/TemplateHaskell/TH.hs:13:1: intQQ
+main: test/Spec/TemplateHaskell/TH.hs:21:1: zero1
+main: test/Spec/TemplateHaskell/TH.hs:24:1: zero2
+main: test/Spec/TemplateHaskell/TH.hs:27:1: zero3
+main: test/Spec/TemplateHaskell/TH.hs:30:1: zero4

--- a/test/Spec/TemplateHaskell.failing
+++ b/test/Spec/TemplateHaskell.failing
@@ -1,5 +1,3 @@
-main: test/Spec/TemplateHaskell/TH.hs:7:1: oneQ
-main: test/Spec/TemplateHaskell/TH.hs:10:1: one
 main: test/Spec/TemplateHaskell/TH.hs:13:1: intQQ
 main: test/Spec/TemplateHaskell/TH.hs:21:1: zero1
 main: test/Spec/TemplateHaskell/TH.hs:24:1: zero2

--- a/test/Spec/TemplateHaskell.toml
+++ b/test/Spec/TemplateHaskell.toml
@@ -1,0 +1,7 @@
+roots = [ "Spec.TemplateHaskell.User.root" ]
+
+type-class-roots = false
+
+unused-types = false
+
+root-instances = []

--- a/test/Spec/TemplateHaskell/TH.hs
+++ b/test/Spec/TemplateHaskell/TH.hs
@@ -1,0 +1,30 @@
+module Spec.TemplateHaskell.TH (intQQ, oneQ) where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+oneQ :: Q Exp
+oneQ = pure . LitE $ IntegerL one
+
+one :: Integer
+one = 1
+
+intQQ :: QuasiQuoter
+intQQ = QuasiQuoter 
+  { quoteExp = pure . LitE . IntegerL . (zero1 +) . read
+  , quotePat = pure . LitP . IntegerL . (zero2 +) . read
+  , quoteType = pure . LitT . NumTyLit . (zero3 +) . read
+  , quoteDec = pure . pure . (\i -> ValD (VarP $ mkName "quote") (NormalB $ LitE $ IntegerL i) []) . (zero4 +) . read
+  }
+
+zero1 :: Integer
+zero1 = 0
+
+zero2 :: Integer
+zero2 = 0
+
+zero3 :: Integer
+zero3 = 0
+
+zero4 :: Integer
+zero4 = 0

--- a/test/Spec/TemplateHaskell/TH.hs
+++ b/test/Spec/TemplateHaskell/TH.hs
@@ -1,4 +1,4 @@
-module Spec.TemplateHaskell.TH (intQQ, oneQ) where
+module Spec.TemplateHaskell.TH (intQQ, oneQ, twoQ, two) where
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
@@ -8,6 +8,12 @@ oneQ = pure . LitE $ IntegerL one
 
 one :: Integer
 one = 1
+
+two :: Int
+two = 2
+
+twoQ :: Q Exp
+twoQ = pure . VarE $ mkName "two"
 
 intQQ :: QuasiQuoter
 intQQ = QuasiQuoter 

--- a/test/Spec/TemplateHaskell/TH.hs
+++ b/test/Spec/TemplateHaskell/TH.hs
@@ -1,4 +1,4 @@
-module Spec.TemplateHaskell.TH (intQQ, oneQ, twoQ, two) where
+module Spec.TemplateHaskell.TH (intQQ, oneQ, twoQ, two, three, threeQ) where
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
@@ -14,6 +14,12 @@ two = 2
 
 twoQ :: Q Exp
 twoQ = pure . VarE $ mkName "two"
+
+three :: Int
+three = 3
+
+threeQ :: Q [Dec]
+threeQ = pure [ValD (VarP $ mkName "three'") (NormalB . VarE $ mkName "three") []]
 
 intQQ :: QuasiQuoter
 intQQ = QuasiQuoter 

--- a/test/Spec/TemplateHaskell/User.hs
+++ b/test/Spec/TemplateHaskell/User.hs
@@ -5,13 +5,13 @@
 
 module Spec.TemplateHaskell.User where
 
-import Spec.TemplateHaskell.TH (intQQ, oneQ)
+import Spec.TemplateHaskell.TH (intQQ, oneQ, twoQ, two)
 import GHC.TypeLits (Nat)
 
 newtype T (a :: Nat) = T Int
 
 root :: T [intQQ|1|]
-root = T $ $(oneQ) + [intQQ|1|] + quote + f (1 :: Int)
+root = T $ $(oneQ) + [intQQ|1|] + quote + f (1 :: Int) + $(twoQ)
   where
     f [intQQ|1|] = 1
     f _ = 1

--- a/test/Spec/TemplateHaskell/User.hs
+++ b/test/Spec/TemplateHaskell/User.hs
@@ -5,13 +5,15 @@
 
 module Spec.TemplateHaskell.User where
 
-import Spec.TemplateHaskell.TH (intQQ, oneQ, twoQ, two)
+import Spec.TemplateHaskell.TH
 import GHC.TypeLits (Nat)
+
+$(threeQ)
 
 newtype T (a :: Nat) = T Int
 
 root :: T [intQQ|1|]
-root = T $ $(oneQ) + [intQQ|1|] + quote + f (1 :: Int) + $(twoQ)
+root = T $ $(oneQ) + [intQQ|1|] + quote + f (1 :: Int) + $(twoQ) + three'
   where
     f [intQQ|1|] = 1
     f _ = 1

--- a/test/Spec/TemplateHaskell/User.hs
+++ b/test/Spec/TemplateHaskell/User.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 
 module Spec.TemplateHaskell.User where
 

--- a/test/Spec/TemplateHaskell/User.hs
+++ b/test/Spec/TemplateHaskell/User.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DataKinds #-}
+
+module Spec.TemplateHaskell.User where
+
+import Spec.TemplateHaskell.TH (intQQ, oneQ)
+import GHC.TypeLits (Nat)
+
+newtype T (a :: Nat) = T Int
+
+root :: T [intQQ|1|]
+root = T $ $(oneQ) + [intQQ|1|] + quote + f (1 :: Int)
+  where
+    f [intQQ|1|] = 1
+    f _ = 1
+
+quote :: Int
+[intQQ|2|]

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -76,6 +76,7 @@ test-suite weeder-test
     , tasty
     , tasty-hunit-compat
     , tasty-golden
+    , template-haskell
     , text
     , toml-reader
     , weeder
@@ -107,6 +108,8 @@ test-suite weeder-test
     Spec.RangeEnum.RangeEnum
     Spec.RootClasses.RootClasses
     Spec.StandaloneDeriving.StandaloneDeriving
+    Spec.TemplateHaskell.TH
+    Spec.TemplateHaskell.User
     Spec.TypeAliasGADT.TypeAliasGADT
     Spec.TypeDataDecl.TypeDataDecl
     Spec.Types.Types


### PR DESCRIPTION
See #152 

It seems that as of GHC 9.6 the results of splices are already correctly analysed by Weeder, but the splice functions themselves are not (except for `Q Exp` splices).