### PR TITLE
Fix ModuleRoot test failure

### DIFF
--- a/test/Spec/ModuleRoot.stdout
+++ b/test/Spec/ModuleRoot.stdout
@@ -1,2 +1,2 @@
-test/Spec/ModuleRoot/InstanceNotRoot.hs:9: (Instance) :: C T
-test/Spec/ModuleRoot/M.hs:11: weed
+main: test/Spec/ModuleRoot/InstanceNotRoot.hs:9:1: (Instance) :: C T
+main: test/Spec/ModuleRoot/M.hs:11:1: weed


### PR DESCRIPTION
Fixes #176

This was caused by me forgetting to update the expected output of the test in #157 for #155 and #156, which added column numbers and package names to the output.