### PR TITLE
Add `source-repository` section to Cabal file

### DIFF
--- a/weeder.cabal
+++ b/weeder.cabal
@@ -20,6 +20,10 @@ extra-source-files:
     test/Spec/*.stdout
     test/Spec/*.failing
 
+source-repository head
+  type:     git
+  location: git://github.com/ocharles/weeder.git
+
 library
   build-depends:
     , algebraic-graphs     ^>= 0.7


### PR DESCRIPTION
If nothing else, this enables `cabal get weeder --source`.