### PR TITLE
Try speeding up weeder with a bloom filter

### DIFF
--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -52,6 +52,7 @@ import Data.Set ( Set )
 import qualified Data.Set as Set
 import Data.Tree (Tree)
 import qualified Data.Tree as Tree
+import Data.BloomFilter.Hash
 
 -- generic-lens
 import Data.Generics.Labels ()
@@ -138,6 +139,10 @@ instance Show Declaration where
   show =
     declarationStableName
 
+
+-- TODO maybe we can make this faster by only hashing the location.
+instance Hashable Declaration where
+  hashIO32 d s = hashIO32 (declarationStableName d) s
 
 declarationStableName :: Declaration -> String
 declarationStableName Declaration { declModule, declOccName } =

--- a/src/Weeder/Run.hs
+++ b/src/Weeder/Run.hs
@@ -17,6 +17,7 @@ import Data.Function ( (&) )
 import Data.Set ( Set )
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
+import qualified Data.BloomFilter.Easy as BloomFilter
 
 -- ghc
 import GHC.Plugins
@@ -117,7 +118,9 @@ runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, root
     -- We only care about dead declarations if they have a span assigned,
     -- since they don't show up in the output otherwise
     dead =
-      outputableDeclarations analysis Set.\\ reachableSet
+      fastSpecialSetDifference 
+        (outputableDeclarations analysis)
+        reachableSet
 
     warnings =
       Map.unionsWith (++) $
@@ -173,3 +176,17 @@ runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, root
 displayDeclaration :: Declaration -> String
 displayDeclaration d = 
   moduleNameString ( moduleName ( declModule d ) ) <> "." <> occNameString ( declOccName d )
+
+-- | This computes the same as (Set.\\) but is faster by assuming that the set difference will be small.
+-- I.e. there will be more non-weeds than weeds.
+--
+fastSpecialSetDifference :: Set Declaration -> Set Declaration -> Set Declaration
+fastSpecialSetDifference allDecls usedDecls = 
+  let bloom = BloomFilter.easyList 0.05 (Set.toList usedDecls)
+      -- The elem docs say:
+      -- @
+      -- If the value is present, return True. If the value is not present, there is still some possibility that True will be returned.
+      -- @
+      -- I.e. if some declaration is a weed, it will definitely show up in the result, but also some weeds will show up in the result.
+      -- So we need to do another set difference afterwards, but with a much smaller set.
+  in Set.difference (Set.filter (not . (`BloomFilter.elem` bloom)) allDecls) usedDecls

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -40,6 +40,7 @@ library
     , text                 ^>= 2.0.1 || ^>= 2.1
     , toml-reader          ^>= 0.2.0.0
     , transformers         ^>= 0.5.6.2 || ^>= 0.6
+    , bloomfilter          ^>= 2.0.1.2
   hs-source-dirs: src
   exposed-modules:
     Weeder


### PR DESCRIPTION
I had this idea last night so I wanted to try it out, but it looks like this isn't actually faster:

```
Test with these changes:                       
weeder-check> real      0m32.576s
weeder-check> user      0m30.698s
weeder-check> sys       0m1.788s
 
Test without these changes:
weeder-check> real      0m31.765s
weeder-check> user      0m30.047s
weeder-check> sys       0m1.633s
```

Perhaps this could still work with a better hash function or some more tuning with respect to how the bloom filter is constructed.

@ocharles I figured you might still like to see this, even though the experiment seems to have failed.
Feel free to close this PR