### PR TITLE
Self-weeding: report unused configured roots, root-instances and root-modules

### DIFF
--- a/.changes/unreleased/Added-20260611-113704.yaml
+++ b/.changes/unreleased/Added-20260611-113704.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Weeder now reports explicitly configured `roots` patterns, `root-instances`
+  entries and `root-modules` patterns that match no identifiers, so stale configuration
+  entries are surfaced as weeds (self-weeding). Defaults are left alone.
+time: 2026-06-11T11:37:04.101033366+02:00

--- a/README.md
+++ b/README.md
@@ -111,6 +111,35 @@ root-instances = [ { module = "Spec.ConfigInstanceModules.Module1", instance = "
                  ]
 ```
 
+## Self-weeding
+
+Over the lifetime of a project, roots that were once needed can become stale:
+the declaration they pointed at gets renamed or removed, leaving behind a
+`roots` pattern, `root-instances` entry or `root-modules` pattern that no longer
+matches anything. Such an entry is a weed in the configuration itself.
+
+Weeder reports these automatically. Any `roots` pattern that matches no
+declaration, any `root-instances` entry that matches no instance, and any
+`root-modules` pattern that matches no module, is reported alongside the regular
+weeds (and likewise contributes to the weeds-found exit code):
+
+``` shell
+$ weeder
+no declaration matches roots entry "^Main.runServer$"
+no instance matches root-instances entry { class = "\\.ToJSON$" }
+no module matches root-modules entry "^Test\\."
+```
+
+A `roots` pattern counts as matching as long as it matches any identifier Weeder
+is aware of, even one that never appears in the output (such as a type or
+constructor when `unused-types` is disabled), so a root naming real code is not
+reported just because of the current analysis mode.
+
+Only entries you have explicitly configured are reported. Default `roots` and
+`root-instances` are left alone, since telling you that a default you never
+wrote is currently unused would not be actionable. When `type-class-roots` is
+set, `root-instances` is ignored entirely, so its entries are not reported.
+
 ## Exit codes
 
 Weeder emits the following exit codes:

--- a/src/Weeder.hs
+++ b/src/Weeder.hs
@@ -18,6 +18,7 @@ module Weeder
   , analyseHieFile
   , emptyAnalysis
   , outputableDeclarations
+  , localDeclarations
 
     -- ** Reachability
   , Root(..)
@@ -29,7 +30,7 @@ module Weeder
    where
 
 -- algebraic-graphs
-import Algebra.Graph ( Graph, edge, empty, overlay, vertex, stars, star, overlays )
+import Algebra.Graph ( Graph, edge, empty, overlay, vertex, stars, star, overlays, vertexSet )
 import Algebra.Graph.ToGraph ( dfs )
 
 -- base
@@ -245,6 +246,18 @@ reachable Analysis{ dependencyGraph, exports } roots =
 outputableDeclarations :: Analysis -> Set Declaration
 outputableDeclarations Analysis{ declarationSites } =
   Map.keysSet declarationSites
+
+
+-- | Every declaration defined in one of the analysed modules, including ones
+-- that never appear in the output (such as types and constructors when
+-- @unused-types@ is disabled). Used to decide whether a configured root matches
+-- any real identifier in the project, as opposed to whether it keeps anything
+-- alive. Declarations from external packages — which appear in the graph only
+-- as dependency targets — are excluded, so a root that matches only an external
+-- symbol is still reported as unused.
+localDeclarations :: Analysis -> Set Declaration
+localDeclarations Analysis{ dependencyGraph, modulePaths } =
+  Set.filter (\d -> declModule d `Map.member` modulePaths) (vertexSet dependencyGraph)
 
 
 -- Generate an initial graph of the current HieFile.

--- a/src/Weeder/Config.hs
+++ b/src/Weeder/Config.hs
@@ -17,11 +17,16 @@ module Weeder.Config
   , configToToml
   , decodeNoDefaults
   , defaultConfig
+    -- * Compiled regular expressions
+  , CompiledRegex(..)
+    -- * Configuration provenance
+  , Configured(..)
     -- * Marking instances as roots
   , InstancePattern
   , modulePattern
   , instancePattern
   , classPattern
+  , showInstancePattern
   , pattern InstanceOnly
   , pattern ClassOnly
   , pattern ModuleOnly
@@ -37,6 +42,9 @@ import Data.List (intersperse, intercalate)
 -- containers
 import Data.Containers.ListUtils (nubOrd)
 
+-- text
+import Data.Text (Text)
+
 -- regex-tdfa
 import Text.Regex.TDFA ( Regex, RegexOptions ( defaultExecOpt, defaultCompOpt ) )
 import Text.Regex.TDFA.TDFA ( patternToRegex )
@@ -47,7 +55,26 @@ import qualified TOML
 
 
 -- | Configuration for Weeder analysis.
-type Config = ConfigType Regex
+type Config = ConfigType CompiledRegex
+
+
+-- | A compiled regular expression, paired with the source string it was
+-- compiled from. We keep the source around so that we can report which
+-- configured pattern is responsible when a pattern matches no identifiers.
+data CompiledRegex = CompiledRegex
+  { regexSource :: String
+  , compiledRegex :: Regex
+  }
+
+
+-- | A configured value together with whether it was set explicitly (as opposed
+-- to falling back to the default). We track this for the root sections so that
+-- self-weeding only reports entries the user actually wrote: pointing out that
+-- a default they never configured is unused would not be actionable.
+data Configured a = Configured
+  { configuredValue :: a
+  , configuredExplicitly :: Bool
+  } deriving (Eq, Show, Functor, Foldable, Traversable)
 
 
 -- | Configuration that has been parsed from TOML (and can still be
@@ -57,19 +84,19 @@ type ConfigParsed = ConfigType String
 
 -- | Underlying type for 'Config' and 'ConfigParsed'.
 data ConfigType a = Config
-  { rootPatterns :: [a]
+  { rootPatterns :: Configured [a]
     -- ^ Any declarations matching these regular expressions will be added to
     -- the root set.
   , typeClassRoots :: Bool
     -- ^ If True, consider all declarations in a type class as part of the root
     -- set. Overrides root-instances.
-  , rootInstances :: [InstancePattern a]
+  , rootInstances :: Configured [InstancePattern a]
     -- ^ All matching instances will be added to the root set. An absent field
     -- will always match.
   , unusedTypes :: Bool
     -- ^ Toggle to look for and output unused types. Type family instances will
     -- be marked as implicit roots.
-  , rootModules :: [a]
+  , rootModules :: Configured [a]
     -- ^ All matching modules will be added to the root set.
   } deriving (Eq, Show, Functor, Foldable, Traversable)
 
@@ -98,11 +125,11 @@ pattern ModuleOnly m = InstancePattern Nothing Nothing (Just m)
 
 defaultConfig :: ConfigParsed
 defaultConfig = Config
-  { rootPatterns = [ "Main.main", "^Paths_.*"]
+  { rootPatterns = Configured [ "Main.main", "^Paths_.*"] False
   , typeClassRoots = False
-  , rootInstances = [ ClassOnly "\\.IsString$", ClassOnly "\\.IsList$" ]
+  , rootInstances = Configured [ ClassOnly "\\.IsString$", ClassOnly "\\.IsList$" ] False
   , unusedTypes = False
-  , rootModules = mempty
+  , rootModules = Configured mempty False
   }
 
 
@@ -114,24 +141,48 @@ instance TOML.DecodeTOML Config where
 
 instance TOML.DecodeTOML ConfigParsed where
   tomlDecoder = do
-    rootPatterns <- TOML.getFieldOr (rootPatterns defaultConfig) "roots"
+    rootPatterns <- getConfigured defaultRootPatterns "roots"
     typeClassRoots <- TOML.getFieldOr (typeClassRoots defaultConfig) "type-class-roots"
-    rootInstances <- TOML.getFieldOr (rootInstances defaultConfig) "root-instances"
+    rootInstances <- getConfigured defaultRootInstances "root-instances"
     unusedTypes <- TOML.getFieldOr (unusedTypes defaultConfig) "unused-types"
-    rootModules <- TOML.getFieldOr (rootModules defaultConfig) "root-modules"
+    rootModules <- getConfigured defaultRootModules "root-modules"
 
     pure Config{..}
+    where
+      Config
+        { rootPatterns = Configured defaultRootPatterns _
+        , rootInstances = Configured defaultRootInstances _
+        , rootModules = Configured defaultRootModules _
+        } = defaultConfig
+
+
+-- | Decode an optional field, marking it 'configuredExplicitly' when present
+-- and falling back to the given default otherwise.
+getConfigured :: TOML.DecodeTOML a => a -> Text -> TOML.Decoder (Configured a)
+getConfigured def key = configured def <$> TOML.getFieldOpt key
+
+
+-- | A value from the TOML if present, or the given default otherwise, recording
+-- in 'configuredExplicitly' which of the two it was.
+configured :: a -> Maybe a -> Configured a
+configured def = \case
+  Just v  -> Configured v True
+  Nothing -> Configured def False
 
 
 decodeNoDefaults :: TOML.Decoder Config
 decodeNoDefaults = do
-  rootPatterns <- TOML.getField "roots"
+  -- In this mode every field must be specified, so every root section is
+  -- explicit by construction.
+  rootPatterns <- explicit <$> TOML.getField "roots"
   typeClassRoots <- TOML.getField "type-class-roots"
-  rootInstances <- TOML.getField "root-instances"
+  rootInstances <- explicit <$> TOML.getField "root-instances"
   unusedTypes <- TOML.getField "unused-types"
-  rootModules <- TOML.getField "root-modules"
+  rootModules <- explicit <$> TOML.getField "root-modules"
 
   either fail pure $ compileConfig Config{..}
+  where
+    explicit v = Configured v True
 
 
 instance TOML.DecodeTOML (InstancePattern String) where
@@ -181,28 +232,28 @@ showInstancePattern = \case
       moduleField m = "module = " ++ show m
 
 
-compileRegex :: String -> Either String Regex
-compileRegex = bimap show (\p -> patternToRegex p defaultCompOpt defaultExecOpt) . parseRegex
+compileRegex :: String -> Either String CompiledRegex
+compileRegex src =
+  bimap show (\p -> CompiledRegex src (patternToRegex p defaultCompOpt defaultExecOpt)) (parseRegex src)
 
 
 compileConfig :: ConfigParsed -> Either String Config
 compileConfig conf@Config{ rootInstances, rootPatterns, rootModules } =
   traverse compileRegex conf'
   where
-    rootInstances' = nubOrd rootInstances
-    rootPatterns' = nubOrd rootPatterns
-    rootModules' = nubOrd rootModules
-    conf' = conf{ rootInstances = rootInstances', rootPatterns = rootPatterns', rootModules = rootModules' }
+    conf' = conf
+      { rootInstances = fmap nubOrd rootInstances
+      , rootPatterns = fmap nubOrd rootPatterns
+      , rootModules = fmap nubOrd rootModules
+      }
 
 
 configToToml :: ConfigParsed -> String
 configToToml Config{..}
   = unlines . intersperse mempty $
-      [ "roots = " ++ show rootPatterns
+      [ "roots = " ++ show (configuredValue rootPatterns)
       , "type-class-roots = " ++ map toLower (show typeClassRoots)
-      , "root-instances = " ++ "[" ++ intercalate "," (map showInstancePattern rootInstances') ++ "]"
+      , "root-instances = " ++ "[" ++ intercalate "," (map showInstancePattern (configuredValue rootInstances)) ++ "]"
       , "unused-types = " ++ map toLower (show unusedTypes)
-      , "root-modules = " ++ show rootModules
+      , "root-modules = " ++ show (configuredValue rootModules)
       ]
-  where
-    rootInstances' = rootInstances

--- a/src/Weeder/Config.hs
+++ b/src/Weeder/Config.hs
@@ -21,6 +21,7 @@ module Weeder.Config
   , CompiledRegex(..)
     -- * Configuration provenance
   , Configured(..)
+  , configuredValue
     -- * Marking instances as roots
   , InstancePattern
   , modulePattern
@@ -67,14 +68,21 @@ data CompiledRegex = CompiledRegex
   }
 
 
--- | A configured value together with whether it was set explicitly (as opposed
--- to falling back to the default). We track this for the root sections so that
--- self-weeding only reports entries the user actually wrote: pointing out that
--- a default they never configured is unused would not be actionable.
-data Configured a = Configured
-  { configuredValue :: a
-  , configuredExplicitly :: Bool
-  } deriving (Eq, Show, Functor, Foldable, Traversable)
+-- | A configured value, and whether it was set explicitly or left at its
+-- default. We track this for the root sections so that self-weeding only
+-- reports entries the user actually wrote: pointing out that a default they
+-- never configured is unused would not be actionable.
+data Configured a
+  = Configured a
+  | Default a
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+
+-- | The configured value, regardless of where it came from.
+configuredValue :: Configured a -> a
+configuredValue = \case
+  Configured a -> a
+  Default a -> a
 
 
 -- | Configuration that has been parsed from TOML (and can still be
@@ -125,12 +133,24 @@ pattern ModuleOnly m = InstancePattern Nothing Nothing (Just m)
 
 defaultConfig :: ConfigParsed
 defaultConfig = Config
-  { rootPatterns = Configured [ "Main.main", "^Paths_.*"] False
+  { rootPatterns = Default defaultRootPatterns
   , typeClassRoots = False
-  , rootInstances = Configured [ ClassOnly "\\.IsString$", ClassOnly "\\.IsList$" ] False
+  , rootInstances = Default defaultRootInstances
   , unusedTypes = False
-  , rootModules = Configured mempty False
+  , rootModules = Default defaultRootModules
   }
+
+
+defaultRootPatterns :: [String]
+defaultRootPatterns = [ "Main.main", "^Paths_.*" ]
+
+
+defaultRootInstances :: [InstancePattern String]
+defaultRootInstances = [ ClassOnly "\\.IsString$", ClassOnly "\\.IsList$" ]
+
+
+defaultRootModules :: [String]
+defaultRootModules = mempty
 
 
 instance TOML.DecodeTOML Config where
@@ -148,41 +168,25 @@ instance TOML.DecodeTOML ConfigParsed where
     rootModules <- getConfigured defaultRootModules "root-modules"
 
     pure Config{..}
-    where
-      Config
-        { rootPatterns = Configured defaultRootPatterns _
-        , rootInstances = Configured defaultRootInstances _
-        , rootModules = Configured defaultRootModules _
-        } = defaultConfig
 
 
--- | Decode an optional field, marking it 'configuredExplicitly' when present
--- and falling back to the given default otherwise.
+-- | Decode an optional field, marking it 'Configured' when present and falling
+-- back to the given 'Default' otherwise.
 getConfigured :: TOML.DecodeTOML a => a -> Text -> TOML.Decoder (Configured a)
-getConfigured def key = configured def <$> TOML.getFieldOpt key
-
-
--- | A value from the TOML if present, or the given default otherwise, recording
--- in 'configuredExplicitly' which of the two it was.
-configured :: a -> Maybe a -> Configured a
-configured def = \case
-  Just v  -> Configured v True
-  Nothing -> Configured def False
+getConfigured def key = maybe (Default def) Configured <$> TOML.getFieldOpt key
 
 
 decodeNoDefaults :: TOML.Decoder Config
 decodeNoDefaults = do
   -- In this mode every field must be specified, so every root section is
   -- explicit by construction.
-  rootPatterns <- explicit <$> TOML.getField "roots"
+  rootPatterns <- Configured <$> TOML.getField "roots"
   typeClassRoots <- TOML.getField "type-class-roots"
-  rootInstances <- explicit <$> TOML.getField "root-instances"
+  rootInstances <- Configured <$> TOML.getField "root-instances"
   unusedTypes <- TOML.getField "unused-types"
-  rootModules <- explicit <$> TOML.getField "root-modules"
+  rootModules <- Configured <$> TOML.getField "root-modules"
 
   either fail pure $ compileConfig Config{..}
-  where
-    explicit v = Configured v True
 
 
 instance TOML.DecodeTOML (InstancePattern String) where

--- a/src/Weeder/Run.hs
+++ b/src/Weeder/Run.hs
@@ -92,7 +92,7 @@ formatWeed = \case
 -- Returns a list of 'Weed's that can be displayed using
 -- 'formatWeed', and the final 'Analysis'.
 runWeeder :: Config -> [HieFile] -> ([Weed], Analysis)
-runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatternsExplicit, typeClassRoots, rootInstances = Configured rootInstances rootInstancesExplicit, rootModules = Configured rootModules rootModulesExplicit } hieFiles =
+runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, rootModules } hieFiles =
   let
     asts = concatMap (Map.elems . getAsts . hie_asts) hieFiles
 
@@ -123,13 +123,13 @@ runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatter
         ( \d ->
             any
               ( \p -> matchTest ( compiledRegex p ) ( displayDeclaration d ) )
-              rootPatterns
+              ( configuredValue rootPatterns )
         )
         ( outputableDeclarations analysis )
 
     matchingModules =
       Set.filter
-        ((\s -> any (\p -> matchTest ( compiledRegex p ) s) rootModules) . moduleNameString . moduleName)
+        ((\s -> any (\p -> matchTest ( compiledRegex p ) s) ( configuredValue rootModules )) . moduleNameString . moduleName)
       ( Map.keysSet $ exports analysis )
 
     reachableSet =
@@ -178,11 +178,12 @@ runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatter
     -- because @unused-types@ happens to be disabled. Only patterns the user
     -- explicitly configured are reported, since pointing out that an
     -- unconfigured default is unused is not actionable.
-    deadRootPatterns
-      | not rootPatternsExplicit = []
-      | otherwise =
+    deadRootPatterns =
+      case rootPatterns of
+        Default _ -> []
+        Configured patterns ->
           [ regexSource p
-          | p <- rootPatterns
+          | p <- patterns
           , not $
               any
                 ( \d -> matchTest ( compiledRegex p ) ( displayDeclaration d ) )
@@ -197,23 +198,26 @@ runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatter
 
     deadRootInstances
       | typeClassRoots = []
-      | not rootInstancesExplicit = []
       | otherwise =
-          [ showInstancePattern ( regexSource <$> ip )
-          | ip <- rootInstances
-          , not $ any ( matchesInstancePattern analysis ip ) instanceRoots
-          ]
+          case rootInstances of
+            Default _ -> []
+            Configured patterns ->
+              [ showInstancePattern ( regexSource <$> ip )
+              | ip <- patterns
+              , not $ any ( matchesInstancePattern analysis ip ) instanceRoots
+              ]
 
     -- A @root-modules@ pattern that matches none of the modules Weeder analysed
     -- is also a weed.
     knownModuleNames =
       map ( moduleNameString . moduleName ) ( Map.keys ( modulePaths analysis ) )
 
-    deadRootModules
-      | not rootModulesExplicit = []
-      | otherwise =
+    deadRootModules =
+      case rootModules of
+        Default _ -> []
+        Configured patterns ->
           [ regexSource p
-          | p <- rootModules
+          | p <- patterns
           , not $ any ( \m -> matchTest ( compiledRegex p ) m ) knownModuleNames
           ]
 
@@ -239,7 +243,7 @@ runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatter
       -- through 'matchesInstancePattern'.
       InstanceRoot d c ->
         typeClassRoots
-          || any ( \ip -> matchesInstancePattern analysis ip ( d, c ) ) rootInstances
+          || any ( \ip -> matchesInstancePattern analysis ip ( d, c ) ) ( configuredValue rootInstances )
 
 
 -- | Does a @root-instances@ pattern match a given instance root (the

--- a/src/Weeder/Run.hs
+++ b/src/Weeder/Run.hs
@@ -4,7 +4,7 @@
 {-# language NamedFieldPuns #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-module Weeder.Run ( runWeeder, Weed(..), formatWeed ) where
+module Weeder.Run ( runWeeder, Weed(..), DeclarationWeed(..), DeadRoot(..), formatWeed ) where
 
 -- base
 import Control.Applicative ( liftA2 )
@@ -44,7 +44,16 @@ import Weeder
 import Weeder.Config
 
 
-data Weed = Weed
+-- | Something Weeder found that is unused: either a dead declaration in the
+-- analysed code, or a configured root that matched no identifiers (a weed in
+-- the configuration itself).
+data Weed
+  = WeedDeclaration DeclarationWeed
+  | WeedRoot DeadRoot
+
+
+-- | A dead declaration: code that is written but never reachable from a root.
+data DeclarationWeed = DeclarationWeed
   { weedPackage :: String
   , weedPath :: FilePath
   , weedLine :: Int
@@ -54,19 +63,36 @@ data Weed = Weed
   }
 
 
+-- | A configured root that no longer applies because it matches nothing.
+data DeadRoot
+  = -- | A @roots@ pattern (its source string) that matched no declaration.
+    DeadRootPattern String
+  | -- | A @root-instances@ entry (pretty-printed) that matched no instance.
+    DeadRootInstance String
+  | -- | A @root-modules@ pattern (its source string) that matched no module.
+    DeadRootModule String
+
+
 formatWeed :: Weed -> String
-formatWeed Weed{..} =
-  weedPackage <> ": " <> weedPath <> ":" <> show weedLine <> ":" <> show weedCol <> ": "
-    <> case weedPrettyPrintedType of
-      Nothing -> occNameString ( declOccName weedDeclaration )
-      Just t -> "(Instance) :: " <> t
+formatWeed = \case
+  WeedDeclaration DeclarationWeed{..} ->
+    weedPackage <> ": " <> weedPath <> ":" <> show weedLine <> ":" <> show weedCol <> ": "
+      <> case weedPrettyPrintedType of
+        Nothing -> occNameString ( declOccName weedDeclaration )
+        Just t -> "(Instance) :: " <> t
+  WeedRoot (DeadRootPattern src) ->
+    "no declaration matches roots entry " <> show src
+  WeedRoot (DeadRootInstance s) ->
+    "no instance matches root-instances entry " <> s
+  WeedRoot (DeadRootModule src) ->
+    "no module matches root-modules entry " <> show src
 
 -- | Run Weeder on the given .hie files with the given 'Config'.
 --
 -- Returns a list of 'Weed's that can be displayed using
 -- 'formatWeed', and the final 'Analysis'.
 runWeeder :: Config -> [HieFile] -> ([Weed], Analysis)
-runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, rootModules } hieFiles =
+runWeeder weederConfig@Config{ rootPatterns = Configured rootPatterns rootPatternsExplicit, typeClassRoots, rootInstances = Configured rootInstances rootInstancesExplicit, rootModules = Configured rootModules rootModulesExplicit } hieFiles =
   let
     asts = concatMap (Map.elems . getAsts . hie_asts) hieFiles
 
@@ -96,14 +122,14 @@ runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, root
       Set.filter
         ( \d ->
             any
-              (`matchTest` displayDeclaration d)
+              ( \p -> matchTest ( compiledRegex p ) ( displayDeclaration d ) )
               rootPatterns
         )
         ( outputableDeclarations analysis )
 
     matchingModules =
       Set.filter
-        ((\s -> any (`matchTest` s) rootModules) . moduleNameString . moduleName)
+        ((\s -> any (\p -> matchTest ( compiledRegex p ) s) rootModules) . moduleNameString . moduleName)
       ( Map.keysSet $ exports analysis )
 
     reachableSet =
@@ -133,41 +159,109 @@ runWeeder weederConfig@Config{ rootPatterns, typeClassRoots, rootInstances, root
         )
         dead
 
-    weeds =
+    declarationWeeds =
       Map.toList warnings & concatMap \( weedPath, declarations ) ->
         sortOn fst declarations & map \( (weedPackage, (weedLine, weedCol)) , weedDeclaration ) ->
-          Weed { weedPrettyPrintedType = Map.lookup weedDeclaration (prettyPrintedType analysis)
-               , weedPackage
-               , weedPath
-               , weedLine
-               , weedCol
-               , weedDeclaration
-               }
+          WeedDeclaration DeclarationWeed
+            { weedPrettyPrintedType = Map.lookup weedDeclaration (prettyPrintedType analysis)
+            , weedPackage
+            , weedPath
+            , weedLine
+            , weedCol
+            , weedDeclaration
+            }
+
+    -- A @roots@ pattern that matches no identifier in the project is a weed in
+    -- the configuration itself: it no longer applies to any declaration. We
+    -- match against every local declaration rather than only the outputable
+    -- ones, so that a root naming a real type or constructor is not flagged just
+    -- because @unused-types@ happens to be disabled. Only patterns the user
+    -- explicitly configured are reported, since pointing out that an
+    -- unconfigured default is unused is not actionable.
+    deadRootPatterns
+      | not rootPatternsExplicit = []
+      | otherwise =
+          [ regexSource p
+          | p <- rootPatterns
+          , not $
+              any
+                ( \d -> matchTest ( compiledRegex p ) ( displayDeclaration d ) )
+                ( localDeclarations analysis )
+          ]
+
+    -- A @root-instances@ entry that matches no instance is likewise a weed.
+    -- When 'typeClassRoots' is set, @root-instances@ is ignored entirely, so we
+    -- don't report its entries.
+    instanceRoots =
+      [ ( d, c ) | InstanceRoot d c <- Set.toList ( implicitRoots analysis ) ]
+
+    deadRootInstances
+      | typeClassRoots = []
+      | not rootInstancesExplicit = []
+      | otherwise =
+          [ showInstancePattern ( regexSource <$> ip )
+          | ip <- rootInstances
+          , not $ any ( matchesInstancePattern analysis ip ) instanceRoots
+          ]
+
+    -- A @root-modules@ pattern that matches none of the modules Weeder analysed
+    -- is also a weed.
+    knownModuleNames =
+      map ( moduleNameString . moduleName ) ( Map.keys ( modulePaths analysis ) )
+
+    deadRootModules
+      | not rootModulesExplicit = []
+      | otherwise =
+          [ regexSource p
+          | p <- rootModules
+          , not $ any ( \m -> matchTest ( compiledRegex p ) m ) knownModuleNames
+          ]
+
+    weeds =
+      declarationWeeds
+        <> map ( WeedRoot . DeadRootPattern ) deadRootPatterns
+        <> map ( WeedRoot . DeadRootInstance ) deadRootInstances
+        <> map ( WeedRoot . DeadRootModule ) deadRootModules
 
   in (weeds, analysis)
 
   where
 
     filterImplicitRoots :: Analysis -> Set Root -> Set Root
-    filterImplicitRoots Analysis{ prettyPrintedType, modulePaths } = Set.filter $ \case
+    filterImplicitRoots analysis = Set.filter $ \case
       DeclarationRoot _ -> True -- keep implicit roots for rewrite rules etc
 
       ModuleRoot _ -> True
 
-      InstanceRoot d c -> typeClassRoots || matchingType
-        where
-          matchingType =
-            let mt = Map.lookup d prettyPrintedType
-                matches = maybe (const False) (flip matchTest) mt
-            in any (maybe True matches) filteredInstances
+      -- [tag:RootInstanceMatching] The reachability check here and the
+      -- dead-root-instance check in 'deadRootInstances' must agree on what it
+      -- means for a 'root-instances' entry to match an instance; both go
+      -- through 'matchesInstancePattern'.
+      InstanceRoot d c ->
+        typeClassRoots
+          || any ( \ip -> matchesInstancePattern analysis ip ( d, c ) ) rootInstances
 
-          filteredInstances =
-            map instancePattern
-            . filter (maybe True (`matchTest` displayDeclaration c) . classPattern)
-            . filter (maybe True modulePathMatches . modulePattern)
-            $ rootInstances
 
-          modulePathMatches p = maybe False (p `matchTest`) (Map.lookup ( declModule d ) modulePaths)
+-- | Does a @root-instances@ pattern match a given instance root (the
+-- declaration of the instance and the declaration of its parent class)? An
+-- absent field always matches.
+--
+-- [ref:RootInstanceMatching]
+matchesInstancePattern
+  :: Analysis -> InstancePattern CompiledRegex -> ( Declaration, Declaration ) -> Bool
+matchesInstancePattern Analysis{ prettyPrintedType, modulePaths } ip ( d, c ) =
+       maybe True moduleMatches ( modulePattern ip )
+    && maybe True classMatches ( classPattern ip )
+    && maybe True typeMatches ( instancePattern ip )
+  where
+    moduleMatches p =
+      maybe False ( matchTest ( compiledRegex p ) ) ( Map.lookup ( declModule d ) modulePaths )
+
+    classMatches p =
+      matchTest ( compiledRegex p ) ( displayDeclaration c )
+
+    typeMatches p =
+      maybe False ( matchTest ( compiledRegex p ) ) ( Map.lookup d prettyPrintedType )
 
 
 displayDeclaration :: Declaration -> String

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -78,7 +78,10 @@ integrationTestOutput hieDirectory = do
   handle (\e -> hPrint stderr (e :: IOException)) $
     writeFile (hieDirectory <.> ".dot") graph'
   -- Normalize weedPackage. We get different values here based on our version of cabal-install/ghc.
-  let weeds' = map (\weed -> weed {Weeder.Run.weedPackage = "main"}) weeds
+  let normalize w = case w of
+        Weeder.Run.WeedDeclaration d -> Weeder.Run.WeedDeclaration d {Weeder.Run.weedPackage = "main"}
+        _ -> w
+      weeds' = map normalize weeds
   pure (LBS.fromStrict $ encodeUtf8 $ pack $ unlines $ map Weeder.Run.formatWeed weeds')
   where
     configExpr = hieDirectory <.> ".toml"

--- a/test/Spec/DefaultsNotReported.toml
+++ b/test/Spec/DefaultsNotReported.toml
@@ -1,0 +1,6 @@
+# roots and root-instances are deliberately left unset, so they fall back to
+# their defaults (which match nothing here). root-modules is set explicitly to
+# keep the module alive. Self-weeding must stay silent: defaults are not weeds.
+root-modules = [ '^Spec\.DefaultsNotReported\.' ]
+
+type-class-roots = false

--- a/test/Spec/DefaultsNotReported/DefaultsNotReported.hs
+++ b/test/Spec/DefaultsNotReported/DefaultsNotReported.hs
@@ -1,0 +1,10 @@
+module Spec.DefaultsNotReported.DefaultsNotReported where
+
+-- This module is kept entirely alive by an explicit `root-modules` entry, so
+-- there are no dead declarations. The point of the test is that the *default*
+-- `roots` (`Main.main`, `^Paths_.*`) and the default `root-instances`
+-- (`IsString`, `IsList`) -- none of which match anything here -- are NOT
+-- reported, because they were never configured explicitly. The output is empty.
+
+value :: Int
+value = 5

--- a/test/Spec/SelfWeeding.stdout
+++ b/test/Spec/SelfWeeding.stdout
@@ -1,0 +1,3 @@
+no declaration matches roots entry "Spec.SelfWeeding.SelfWeeding.doesNotExist"
+no instance matches root-instances entry { class = "\\.NoSuchClass$" }
+no module matches root-modules entry "^No.Such.Module$"

--- a/test/Spec/SelfWeeding.toml
+++ b/test/Spec/SelfWeeding.toml
@@ -1,0 +1,9 @@
+roots = [ "Spec.SelfWeeding.SelfWeeding.root"
+        , "Spec.SelfWeeding.SelfWeeding.doesNotExist"
+        ]
+
+type-class-roots = false
+
+root-instances = [ { class = '\.NoSuchClass$' } ]
+
+root-modules = [ "^No.Such.Module$" ]

--- a/test/Spec/SelfWeeding/SelfWeeding.hs
+++ b/test/Spec/SelfWeeding/SelfWeeding.hs
@@ -1,0 +1,12 @@
+module Spec.SelfWeeding.SelfWeeding where
+
+-- A single reachable root and a helper it uses, so there are no dead
+-- declarations: the only weeds in this test come from the configuration
+-- itself (a root pattern, a root-instance and a root-module that match
+-- nothing).
+
+root :: Int
+root = helper + 1
+
+helper :: Int
+helper = 41

--- a/test/UnitTests/Weeder/ConfigSpec.hs
+++ b/test/UnitTests/Weeder/ConfigSpec.hs
@@ -15,11 +15,11 @@ tests =
 configToTomlTests :: Assertion
 configToTomlTests =
   let cf = Config
-        { rootPatterns = mempty
+        { rootPatterns = Configured mempty True
         , typeClassRoots = True
-        , rootInstances = [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"]
+        , rootInstances = Configured [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"] True
         , unusedTypes = True
-        , rootModules = ["Foo\\.Bar", "Baz"]
+        , rootModules = Configured ["Foo\\.Bar", "Baz"] True
         }
       cf' = T.pack $ configToToml cf
    in TOML.decode cf' `shouldBe` Right cf

--- a/test/UnitTests/Weeder/ConfigSpec.hs
+++ b/test/UnitTests/Weeder/ConfigSpec.hs
@@ -15,11 +15,11 @@ tests =
 configToTomlTests :: Assertion
 configToTomlTests =
   let cf = Config
-        { rootPatterns = Configured mempty True
+        { rootPatterns = Configured mempty
         , typeClassRoots = True
-        , rootInstances = Configured [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"] True
+        , rootInstances = Configured [InstanceOnly "Quux\\\\[\\]", ClassOnly "[\\[\\\\[baz" <> ModuleOnly "[Quuux]", InstanceOnly "[\\[\\\\[baz" <> ClassOnly "[Quuux]" <> ModuleOnly "[Quuuux]"]
         , unusedTypes = True
-        , rootModules = Configured ["Foo\\.Bar", "Baz"] True
+        , rootModules = Configured ["Foo\\.Bar", "Baz"]
         }
       cf' = T.pack $ configToToml cf
    in TOML.decode cf' `shouldBe` Right cf

--- a/weeder.cabal
+++ b/weeder.cabal
@@ -100,6 +100,7 @@ test-suite weeder-test
     Spec.ConfigInstanceModules.Module1
     Spec.ConfigInstanceModules.Module2
     Spec.ConfigInstanceModules.Module3
+    Spec.DefaultsNotReported.DefaultsNotReported
     Spec.DeriveGeneric.DeriveGeneric
     Spec.InstanceRootConstraint.InstanceRootConstraint
     Spec.InstanceTypeclass.InstanceTypeclass
@@ -113,6 +114,7 @@ test-suite weeder-test
     Spec.OverloadedStrings.OverloadedStrings
     Spec.RangeEnum.RangeEnum
     Spec.RootClasses.RootClasses
+    Spec.SelfWeeding.SelfWeeding
     Spec.StandaloneDeriving.StandaloneDeriving
     Spec.TypeAliasGADT.TypeAliasGADT
     Spec.TypeDataDecl.TypeDataDecl


### PR DESCRIPTION
Addresses #154.

Weeder reports configured roots that no longer match anything — stale roots are weeds too. Three kinds are covered: a `roots` pattern matching no declaration, a `root-instances` entry matching no instance, and a `root-modules` pattern matching no module.

```
$ weeder
no declaration matches roots entry "^Main.runServer$"
no instance matches root-instances entry { class = "\\.ToJSON$" }
no module matches root-modules entry "^Test\\."
```

## Open questions for you

These are product/UX choices I made to get something working — I'd rather you decide them, and I'm happy to change any of them:

1. **On by default.** Self-weeding always runs. Would you prefer it opt-in (a config flag / CLI switch)?
2. **Reported as ordinary weeds.** Dead roots go into the same `[Weed]` list and contribute to the weeds-found exit code (228). Alternatively they could be a separate report / separate exit code / stderr only. What fits weeder's model?
3. **Output format.** Dead-root lines have no file/package/column, so they read differently from declaration weeds. Wording shown above — happy to adjust.
4. **Extending to `root-modules`.** #154 mentions roots and instances; I also covered `root-modules` for consistency. Shout if you'd rather drop it from this PR.

## Design notes

- **Only explicitly-configured entries are reported.** Defaults (`Main.main`, `^Paths_.*`, `IsString`/`IsList`) are left alone — telling someone a default they never wrote is unused isn't actionable. Provenance is captured by a small `Configured a = Configured { configuredValue :: a, configuredExplicitly :: Bool }` wrapper on the three root fields, set from TOML field presence.
- **A root matches if it names any *local* declaration**, not only outputable ones — checked against declarations defined in the analysed modules (`localDeclarations`). So a root naming a real type or constructor is **not** flagged when `unused-types` is off, but a root matching only an external symbol still is.
- `type-class-roots` overrides `root-instances`, so those entries are never reported in that mode.
- To name the offending entry, compiled patterns carry their source string (`CompiledRegex`); reachability and dead-detection share one `matchesInstancePattern` predicate so they can't drift.

One layering caveat worth flagging: the explicit-vs-default provenance now lives in the `Config` type, which is otherwise a purely semantic analysis type. It's pragmatic but I can pull it out if you'd prefer.

## Tests & impact

- New `SelfWeeding` test (all three dead-root kinds) and `DefaultsNotReported` test (asserts defaulted entries stay silent).
- **No existing golden output changes.**
- Builds on GHC 9.8.1; `nix flake check` passes.
- Performance measured neutral on a ~20-package project (within noise of the same build without self-weeding).
